### PR TITLE
[FIX][BE] Add CreatedBy field to Bucket and initialize it on creation

### DIFF
--- a/internal/models/bucket.go
+++ b/internal/models/bucket.go
@@ -7,12 +7,11 @@ import (
 )
 
 type Bucket struct {
-	ID    uuid.UUID `gorm:"type:uuid;primarykey;default:gen_random_uuid()" json:"id"`
-	Name  string    `gorm:"not null;default:null" json:"name" validate:"required"`
-	Files []File    `json:"files"`
-
+	ID        uuid.UUID      `gorm:"type:uuid;primarykey;default:gen_random_uuid()" json:"id"`
+	Name      string         `gorm:"not null;default:null" json:"name" validate:"required"`
+	Files     []File         `json:"files"`
 	CreatedAt time.Time      `json:"created_at"`
-	CreatedBy time.Time      `json:"created_by"`
+	CreatedBy uuid.UUID      `gorm:"type:uuid;not null" json:"-"`
 	UpdatedAt time.Time      `json:"updated_at"`
 	DeletedAt gorm.DeletedAt `gorm:"index" json:"-"`
 }

--- a/internal/services/bucket.go
+++ b/internal/services/bucket.go
@@ -82,7 +82,9 @@ func (s BucketService) Routes() chi.Router {
 
 func (s BucketService) CreateBucket(user models.UserClaims, _ uuid.UUIDs, body models.BucketCreateBody) (models.Bucket, error) {
 	//TODO: Migrate to SQL transaction
+
 	newBucket := models.Bucket{Name: body.Name}
+	newBucket.CreatedBy = user.UserID
 	s.DB.Create(&newBucket)
 
 	err := groups.InsertGroupBucketViewer(s.Enforcer, newBucket)


### PR DESCRIPTION
The CreatedBy field has been added to the Bucket model to track the user's ID who created the bucket. This field is now set during bucket creation in the CreateBucket method. Additionally, its type was corrected to UUID and marked as non-null.

https://github.com/safebucket/safebucket/issues/46