### PR TITLE
[BE] Use upsert for admin user creation

### DIFF
--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/go-chi/cors"
 	"github.com/google/uuid"
 	"go.uber.org/zap"
+	"gorm.io/gorm/clause"
 	"log"
 	"net/http"
 	"time"
@@ -56,7 +57,10 @@ func main() {
 
 	hash, _ := h.CreateHash(config.Admin.Password)
 	adminUser.HashedPassword = hash
-	db.Create(&adminUser)
+	db.Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "email"}},
+		DoUpdates: clause.AssignmentColumns([]string{"hashed_password"}),
+	}).Create(&adminUser)
 	_ = roles.AddUserToRoleAdmin(e, adminUser)
 
 	//


### PR DESCRIPTION
Implemented the `gorm` on-conflict clause to avoid issues. This ensures the hashed password is updated if a conflict occurs.