### PR TITLE
[Security] Enhance authentication cookie security

### DIFF
--- a/internal/handlers/auth.go
+++ b/internal/handlers/auth.go
@@ -4,10 +4,11 @@ import (
 	h "api/internal/helpers"
 	"context"
 	"fmt"
-	"github.com/go-chi/chi/v5"
-	"go.uber.org/zap"
 	"net/http"
 	"time"
+
+	"github.com/go-chi/chi/v5"
+	"go.uber.org/zap"
 )
 
 type OpenIDBeginFunc func(string, string, string) (string, error)
@@ -70,25 +71,34 @@ func OpenIDCallbackHandler(webUrl string, openidCallback OpenIDCallbackFunc) htt
 		expiration := time.Now().Add(365 * 24 * time.Hour)
 
 		http.SetCookie(w, &http.Cookie{
-			Name:    "safebucket_access_token",
-			Value:   accessToken,
-			Expires: expiration,
-			Path:    "/",
+			Name:     "safebucket_access_token",
+			Value:    accessToken,
+			Expires:  expiration,
+			Path:     "/",
+			SameSite: http.SameSiteStrictMode,
+			Secure:   r.TLS != nil,
+			HttpOnly: true,
 		})
 
 		http.SetCookie(w, &http.Cookie{
-			Name:    "safebucket_auth_provider",
-			Value:   providerName,
-			Expires: expiration,
-			Path:    "/",
+			Name:     "safebucket_auth_provider",
+			Value:    providerName,
+			Expires:  expiration,
+			Path:     "/",
+			SameSite: http.SameSiteStrictMode,
+			Secure:   r.TLS != nil,
+			HttpOnly: true,
 		})
 
 		if refreshToken != "" {
 			http.SetCookie(w, &http.Cookie{
-				Name:    "safebucket_refresh_token",
-				Value:   refreshToken,
-				Expires: expiration,
-				Path:    "/",
+				Name:     "safebucket_refresh_token",
+				Value:    refreshToken,
+				Expires:  expiration,
+				Path:     "/",
+				SameSite: http.SameSiteStrictMode,
+				Secure:   r.TLS != nil,
+				HttpOnly: true,
 			})
 		}
 

--- a/internal/helpers/auth.go
+++ b/internal/helpers/auth.go
@@ -21,6 +21,7 @@ func SetCallbackCookie(w http.ResponseWriter, r *http.Request, name, value strin
 		Name:     name,
 		Value:    value,
 		MaxAge:   int(time.Hour.Seconds()),
+		SameSite: http.SameSiteStrictMode,
 		Secure:   r.TLS != nil,
 		HttpOnly: true,
 	}


### PR DESCRIPTION
Add SameSite=Strict, Secure, and HttpOnly flags to all authentication cookies to prevent CSRF attacks and XSS cookie theft. Applies to access tokens, refresh tokens, auth provider cookies, and callback cookies.