### PR TITLE
[LOCAL] Update minio init script

### DIFF
--- a/deployments/local/docker-compose.yml
+++ b/deployments/local/docker-compose.yml
@@ -41,8 +41,12 @@ services:
 
         echo "MinIO is ready. Configuring NATS notification target..."
 
-        # Add NATS JetStream notification target
-        mc admin config set local notify_nats:safebucket address="nats:4222" subject="safebucket.bucket-events" nats_jetstream="on" tls="off" tls_skip_verify="off"
+        mc admin config set local notify_nats:safebucket \
+          address="nats:4222" \
+          subject="safebucket-bucket-events" \
+          jetstream="off" \
+          tls="off" \
+          tls_skip_verify="off"
 
         # Restart MinIO to apply config
         echo "Restarting MinIO to apply configuration..."
@@ -65,14 +69,7 @@ services:
 
         echo "Adding bucket notification events..."
 
-        # Add bucket notification events for all object operations
         mc event add local/safebucket arn:minio:sqs::safebucket:nats --event put,delete,get
-
-        # If the above fails, try with alternative ARN format
-        if [ $? -ne 0 ]; then
-          echo "Trying alternative ARN format..."
-          mc event add local/safebucket arn:minio:sqs:us-east-1:safebucket:nats --event put,delete,get
-        fi
 
         echo "Verifying bucket notification configuration:"
         mc event list local/safebucket

--- a/templates/config.yaml
+++ b/templates/config.yaml
@@ -49,11 +49,11 @@ events:
   type: jetstream
   queues:
     notifications:
-      name: safebucket:notifications
+      name: safebucket-notifications
     bucket-events:
-      name: safebucket:bucket-events
+      name: safebucket-bucket-events
     object-deletion:
-      name: safebucket:object-deletion
+      name: safebucket-object-deletion
   jetstream:
     host: localhost
     port: 4222


### PR DESCRIPTION
  MinIO bucket events were not being published to NATS, causing the following error:
  [ERR] processPub Parse Error: "safebucket-bucket-events nats_ _INBOX..."
  Error: nats: no response from stream

  Root Causes

  1. Invalid parameter name: Used nats_jetstream instead of jetstream, causing malformed subject names
  2. JetStream mode mismatch: MinIO tried to publish directly to JetStream before the stream existed

  Solution

  - Corrected MinIO NATS notification parameter to jetstream="off"
  - Fixed ARN to use correct format: arn:minio:sqs::safebucket:nats