### PR TITLE
[CI] Add tag trigger builds

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -22,7 +22,7 @@ jobs:
       on-default-branch: ${{ steps.check.outputs.on-default-branch }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0  # Fetch all history to check branch
           persist-credentials: false


### PR DESCRIPTION
  Enable automatic Docker image builds triggered by git tags on the main branch with semantic versioning support.

  Changes

  - Tag-based triggers: Workflow now automatically runs when version tags (e.g., v1.0.0) are pushed
  - Branch restriction: Only tags on the main branch trigger builds to ensure release quality
  - Smart tagging:
    - Stable releases (v1.2.3) → safebucket:1.2.3 + safebucket:latest
    - Pre-releases (v1.0.0-beta.1) → safebucket:1.0.0-beta.1 only (no latest)

  Usage

  # Release a new version
  git checkout main
  git tag v1.0.0
  git push origin v1.0.0
