### PR TITLE
docs: add a hosted deploy option to Quick Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,18 @@ docker compose up -d
 > - `APP__API_URL`
 > - `APP__WEB_URL`
 
+### Hosted
+
+To run Safebucket without a machine of your own:
+
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/safebucket)
+
+You choose an admin email and password at deploy time. Safebucket, PostgreSQL and object
+storage come up together, secrets are generated, and the URL and origin variables above are
+set to the assigned domain, so the external-host note doesn't apply.
+
+Community-maintained template, not an official Safebucket build.
+
 ## Verify Image Signature
 
 All published container images are signed with [cosign](https://github.com/sigstore/cosign) using keyless signing via


### PR DESCRIPTION
Adds a hosted option to *Quick Start*, next to the existing local docker compose path.

Quick Start today gets you Safebucket on localhost, which is the right default. This covers
the people who want a real instance and don't have a box to put it on. One click provisions
Safebucket, PostgreSQL and object storage wired together, generates the token and MFA
encryption secrets, and points the API/web/allowed-origins variables at the assigned domain
— so the external-host caveat in the note above is handled rather than inherited. Admin
email and password are the only two things the user is asked for.

Flagged **community-maintained, not an official Safebucket build**, so there's no implied
endorsement. Happy to reword it, move it, or drop the button and keep a plain link if you'd
prefer.

### How I verified

Deployed the template twice from scratch today:

- All three services reach a healthy running state on first deploy, no retries, no manual steps.
- The app serves over HTTPS on the assigned domain.
- Signing in with the admin credentials the template generated returns `200` with
  `{"mfa_required":false}` against `/api/v1/auth/login`.

README only, no source touched.
