### PR TITLE
fix: Ensure user stats excludes deleted entities

### DIFF
--- a/internal/services/user.go
+++ b/internal/services/user.go
@@ -294,13 +294,14 @@ func (s UserService) GetUserStats(
 	var totalBuckets int64
 	s.DB.Model(&models.Membership{}).
 		Joins("INNER JOIN buckets ON memberships.bucket_id = buckets.id").
-		Where("user_id = ? AND buckets.deleted_at IS NULL", userID).Count(&totalBuckets)
+		Where("memberships.user_id = ? AND memberships.deleted_at IS NULL AND buckets.deleted_at IS NULL", userID).
+		Count(&totalBuckets)
 
 	var totalFiles int64
 	s.DB.Model(&models.File{}).
 		Joins("INNER JOIN memberships ON files.bucket_id = memberships.bucket_id").
 		Joins("INNER JOIN buckets ON files.bucket_id = buckets.id").
-		Where("memberships.user_id = ? AND buckets.deleted_at IS NULL", userID).
+		Where("memberships.user_id = ? AND memberships.deleted_at IS NULL AND buckets.deleted_at IS NULL", userID).
 		Count(&totalFiles)
 
 	return models.UserStatsResponse{

--- a/internal/services/user.go
+++ b/internal/services/user.go
@@ -292,12 +292,12 @@ func (s UserService) GetUserStats(
 	}
 
 	var totalBuckets int64
-	s.DB.Model(&models.Membership{}).Where("user_id = ?", userID).Count(&totalBuckets)
+	s.DB.Model(&models.Membership{}).Where("user_id = ? AND deleted_at IS NULL", userID).Count(&totalBuckets)
 
 	var totalFiles int64
 	s.DB.Model(&models.File{}).
 		Joins("INNER JOIN memberships ON files.bucket_id = memberships.bucket_id").
-		Where("memberships.user_id = ?", userID).
+		Where("memberships.user_id = ? AND files.deleted_at IS NULL", userID).
 		Count(&totalFiles)
 
 	return models.UserStatsResponse{

--- a/internal/services/user.go
+++ b/internal/services/user.go
@@ -292,12 +292,15 @@ func (s UserService) GetUserStats(
 	}
 
 	var totalBuckets int64
-	s.DB.Model(&models.Membership{}).Where("user_id = ? AND deleted_at IS NULL", userID).Count(&totalBuckets)
+	s.DB.Model(&models.Membership{}).
+		Joins("INNER JOIN buckets ON memberships.bucket_id = buckets.id").
+		Where("user_id = ? AND buckets.deleted_at IS NULL", userID).Count(&totalBuckets)
 
 	var totalFiles int64
 	s.DB.Model(&models.File{}).
 		Joins("INNER JOIN memberships ON files.bucket_id = memberships.bucket_id").
-		Where("memberships.user_id = ? AND files.deleted_at IS NULL", userID).
+		Joins("INNER JOIN buckets ON files.bucket_id = buckets.id").
+		Where("memberships.user_id = ? AND buckets.deleted_at IS NULL", userID).
 		Count(&totalFiles)
 
 	return models.UserStatsResponse{

--- a/internal/services/user_test.go
+++ b/internal/services/user_test.go
@@ -1,0 +1,77 @@
+package services
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/safebucket/safebucket/internal/database"
+	"github.com/safebucket/safebucket/internal/models"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func setupUserServiceTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sqlDB.Close() })
+
+	_, err = sqlDB.Exec("PRAGMA foreign_keys = ON")
+	require.NoError(t, err)
+
+	database.RunMigrations(sqlDB, database.DialectSQLite)
+	database.RegisterCallbacks(db)
+
+	return db
+}
+
+func TestGetUserStats(t *testing.T) {
+	db := setupUserServiceTestDB(t)
+	service := UserService{DB: db}
+
+	user := models.User{
+		Email:        "stats-user@example.com",
+		ProviderType: models.LocalProviderType,
+		ProviderKey:  string(models.LocalProviderType),
+		Role:         models.RoleUser,
+	}
+	require.NoError(t, db.Create(&user).Error)
+
+	activeBucket := models.Bucket{Name: "active-bucket", CreatedBy: user.ID}
+	require.NoError(t, db.Create(&activeBucket).Error)
+
+	deletedBucket := models.Bucket{Name: "deleted-bucket", CreatedBy: user.ID}
+	require.NoError(t, db.Create(&deletedBucket).Error)
+
+	activeMembership := models.Membership{UserID: user.ID, BucketID: activeBucket.ID, Group: models.GroupOwner}
+	require.NoError(t, db.Create(&activeMembership).Error)
+
+	deletedMembership := models.Membership{UserID: user.ID, BucketID: deletedBucket.ID, Group: models.GroupOwner}
+	require.NoError(t, db.Create(&deletedMembership).Error)
+	require.NoError(t, db.Delete(&deletedMembership).Error)
+
+	for _, name := range []string{"first.txt", "second.txt"} {
+		file := models.File{Name: name, Status: models.FileStatusUploaded, BucketID: activeBucket.ID, Size: 128}
+		require.NoError(t, db.Create(&file).Error)
+	}
+
+	deletedFile := models.File{
+		Name:     "third.txt",
+		Status:   models.FileStatusUploaded,
+		BucketID: activeBucket.ID,
+		Size:     128,
+	}
+	require.NoError(t, db.Create(&deletedFile).Error)
+	require.NoError(t, db.Delete(&deletedFile).Error)
+
+	response, err := service.GetUserStats(zap.NewNop(), models.UserClaims{}, []uuid.UUID{user.ID})
+	require.NoError(t, err)
+	require.Equal(t, models.UserStatsResponse{TotalFiles: 2, TotalBuckets: 1}, response)
+}

--- a/internal/services/user_test.go
+++ b/internal/services/user_test.go
@@ -33,53 +33,85 @@ func setupUserServiceTestDB(t *testing.T) *gorm.DB {
 }
 
 func TestGetUserStats(t *testing.T) {
-	db := setupUserServiceTestDB(t)
-	service := UserService{DB: db}
+	t.Run("counts only files and buckets with active membership", func(t *testing.T) {
+		db := setupUserServiceTestDB(t)
+		service := UserService{DB: db}
 
-	user := models.User{
-		Email:        "stats-user@example.com",
-		ProviderType: models.LocalProviderType,
-		ProviderKey:  string(models.LocalProviderType),
-		Role:         models.RoleUser,
-	}
-	require.NoError(t, db.Create(&user).Error)
+		user := models.User{
+			Email:        "stats-user@example.com",
+			ProviderType: models.LocalProviderType,
+			ProviderKey:  string(models.LocalProviderType),
+			Role:         models.RoleUser,
+		}
+		require.NoError(t, db.Create(&user).Error)
 
-	activeBucket := models.Bucket{Name: "active-bucket", CreatedBy: user.ID}
-	require.NoError(t, db.Create(&activeBucket).Error)
+		activeBucket := models.Bucket{Name: "active-bucket", CreatedBy: user.ID}
+		require.NoError(t, db.Create(&activeBucket).Error)
 
-	deletedBucket := models.Bucket{Name: "deleted-bucket", CreatedBy: user.ID}
-	require.NoError(t, db.Create(&deletedBucket).Error)
+		deletedBucket := models.Bucket{Name: "deleted-bucket", CreatedBy: user.ID}
+		require.NoError(t, db.Create(&deletedBucket).Error)
 
-	activeBucketMembership := models.Membership{UserID: user.ID, BucketID: activeBucket.ID, Group: models.GroupOwner}
-	require.NoError(t, db.Create(&activeBucketMembership).Error)
+		activeBucketMembership := models.Membership{UserID: user.ID, BucketID: activeBucket.ID, Group: models.GroupOwner}
+		require.NoError(t, db.Create(&activeBucketMembership).Error)
 
-	deletedBucketMembership := models.Membership{UserID: user.ID, BucketID: deletedBucket.ID, Group: models.GroupOwner}
-	require.NoError(t, db.Create(&deletedBucketMembership).Error)
-	require.NoError(t, db.Delete(&deletedBucket).Error)
+		deletedBucketMembership := models.Membership{UserID: user.ID, BucketID: deletedBucket.ID, Group: models.GroupOwner}
+		require.NoError(t, db.Create(&deletedBucketMembership).Error)
+		require.NoError(t, db.Delete(&deletedBucket).Error)
 
-	for _, name := range []string{"first.txt", "second.txt"} {
-		file := models.File{Name: name, Status: models.FileStatusUploaded, BucketID: activeBucket.ID, Size: 128}
-		require.NoError(t, db.Create(&file).Error)
-	}
+		for _, name := range []string{"first.txt", "second.txt"} {
+			file := models.File{Name: name, Status: models.FileStatusUploaded, BucketID: activeBucket.ID, Size: 128}
+			require.NoError(t, db.Create(&file).Error)
+		}
 
-	fileInDeletedBucket := models.File{
-		Name:     "ghost.txt",
-		Status:   models.FileStatusUploaded,
-		BucketID: deletedBucket.ID,
-		Size:     128,
-	}
-	require.NoError(t, db.Create(&fileInDeletedBucket).Error)
+		fileInDeletedBucket := models.File{
+			Name:     "ghost.txt",
+			Status:   models.FileStatusUploaded,
+			BucketID: deletedBucket.ID,
+			Size:     128,
+		}
+		require.NoError(t, db.Create(&fileInDeletedBucket).Error)
 
-	deletedFile := models.File{
-		Name:     "third.txt",
-		Status:   models.FileStatusUploaded,
-		BucketID: activeBucket.ID,
-		Size:     128,
-	}
-	require.NoError(t, db.Create(&deletedFile).Error)
-	require.NoError(t, db.Delete(&deletedFile).Error)
+		deletedFile := models.File{
+			Name:     "third.txt",
+			Status:   models.FileStatusUploaded,
+			BucketID: activeBucket.ID,
+			Size:     128,
+		}
+		require.NoError(t, db.Create(&deletedFile).Error)
+		require.NoError(t, db.Delete(&deletedFile).Error)
 
-	response, err := service.GetUserStats(zap.NewNop(), models.UserClaims{}, []uuid.UUID{user.ID})
-	require.NoError(t, err)
-	require.Equal(t, models.UserStatsResponse{TotalFiles: 2, TotalBuckets: 1}, response)
+		response, err := service.GetUserStats(zap.NewNop(), models.UserClaims{}, []uuid.UUID{user.ID})
+		require.NoError(t, err)
+		require.Equal(t, models.UserStatsResponse{TotalFiles: 2, TotalBuckets: 1}, response)
+	})
+
+	t.Run("excludes files and buckets when membership is revoked", func(t *testing.T) {
+		db := setupUserServiceTestDB(t)
+		service := UserService{DB: db}
+
+		user := models.User{
+			Email:        "revoked-user@example.com",
+			ProviderType: models.LocalProviderType,
+			ProviderKey:  string(models.LocalProviderType),
+			Role:         models.RoleUser,
+		}
+		require.NoError(t, db.Create(&user).Error)
+
+		bucket := models.Bucket{Name: "shared-bucket", CreatedBy: user.ID}
+		require.NoError(t, db.Create(&bucket).Error)
+
+		membership := models.Membership{UserID: user.ID, BucketID: bucket.ID, Group: models.GroupOwner}
+		require.NoError(t, db.Create(&membership).Error)
+
+		for _, name := range []string{"a.txt", "b.txt"} {
+			file := models.File{Name: name, Status: models.FileStatusUploaded, BucketID: bucket.ID, Size: 128}
+			require.NoError(t, db.Create(&file).Error)
+		}
+
+		require.NoError(t, db.Delete(&membership).Error)
+
+		response, err := service.GetUserStats(zap.NewNop(), models.UserClaims{}, []uuid.UUID{user.ID})
+		require.NoError(t, err)
+		require.Equal(t, models.UserStatsResponse{TotalFiles: 0, TotalBuckets: 0}, response)
+	})
 }

--- a/internal/services/user_test.go
+++ b/internal/services/user_test.go
@@ -50,17 +50,25 @@ func TestGetUserStats(t *testing.T) {
 	deletedBucket := models.Bucket{Name: "deleted-bucket", CreatedBy: user.ID}
 	require.NoError(t, db.Create(&deletedBucket).Error)
 
-	activeMembership := models.Membership{UserID: user.ID, BucketID: activeBucket.ID, Group: models.GroupOwner}
-	require.NoError(t, db.Create(&activeMembership).Error)
+	activeBucketMembership := models.Membership{UserID: user.ID, BucketID: activeBucket.ID, Group: models.GroupOwner}
+	require.NoError(t, db.Create(&activeBucketMembership).Error)
 
-	deletedMembership := models.Membership{UserID: user.ID, BucketID: deletedBucket.ID, Group: models.GroupOwner}
-	require.NoError(t, db.Create(&deletedMembership).Error)
-	require.NoError(t, db.Delete(&deletedMembership).Error)
+	deletedBucketMembership := models.Membership{UserID: user.ID, BucketID: deletedBucket.ID, Group: models.GroupOwner}
+	require.NoError(t, db.Create(&deletedBucketMembership).Error)
+	require.NoError(t, db.Delete(&deletedBucket).Error)
 
 	for _, name := range []string{"first.txt", "second.txt"} {
 		file := models.File{Name: name, Status: models.FileStatusUploaded, BucketID: activeBucket.ID, Size: 128}
 		require.NoError(t, db.Create(&file).Error)
 	}
+
+	fileInDeletedBucket := models.File{
+		Name:     "ghost.txt",
+		Status:   models.FileStatusUploaded,
+		BucketID: deletedBucket.ID,
+		Size:     128,
+	}
+	require.NoError(t, db.Create(&fileInDeletedBucket).Error)
 
 	deletedFile := models.File{
 		Name:     "third.txt",

--- a/internal/services/user_test.go
+++ b/internal/services/user_test.go
@@ -51,10 +51,18 @@ func TestGetUserStats(t *testing.T) {
 		deletedBucket := models.Bucket{Name: "deleted-bucket", CreatedBy: user.ID}
 		require.NoError(t, db.Create(&deletedBucket).Error)
 
-		activeBucketMembership := models.Membership{UserID: user.ID, BucketID: activeBucket.ID, Group: models.GroupOwner}
+		activeBucketMembership := models.Membership{
+			UserID:   user.ID,
+			BucketID: activeBucket.ID,
+			Group:    models.GroupOwner,
+		}
 		require.NoError(t, db.Create(&activeBucketMembership).Error)
 
-		deletedBucketMembership := models.Membership{UserID: user.ID, BucketID: deletedBucket.ID, Group: models.GroupOwner}
+		deletedBucketMembership := models.Membership{
+			UserID:   user.ID,
+			BucketID: deletedBucket.ID,
+			Group:    models.GroupOwner,
+		}
 		require.NoError(t, db.Create(&deletedBucketMembership).Error)
 		require.NoError(t, db.Delete(&deletedBucket).Error)
 


### PR DESCRIPTION
The existing implementation counts deleted buckets and files towards user stats. I assume that's a bug, since those entities can't be recovered, and in my opinion, it makes sense to exclude them from the statistics. 
Let me know if I misunderstood this, and if that's the expected behavior. 

AI disclosure: AI was used to help me write the test. The test was modeled after existing [callbacks_test.go](https://github.com/safebucket/safebucket/blob/d8711be01b60c73d7daeb546e1617e3fdadc5a61/internal/database/callbacks_test.go) and [garbage_collector_test.go](https://github.com/safebucket/safebucket/blob/d8711be01b60c73d7daeb546e1617e3fdadc5a61/internal/workers/garbage_collector_test.go). I found and fixed the bug myself. 